### PR TITLE
Add mod_init_funcs to mac link section

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,9 @@ pub fn ctor(args: TokenStream, input: TokenStream) -> TokenStream {
                         TokenTree::Punct(Punct::new(',', Spacing::Alone)),
                         TokenTree::Ident(Ident::new("link_section", Span::call_site())),
                         TokenTree::Punct(Punct::new('=', Spacing::Alone)),
-                        TokenTree::Literal(Literal::string("__DATA_CONST,__mod_init_func")),
+                        TokenTree::Literal(Literal::string(
+                            "__DATA_CONST,__mod_init_func,mod_init_funcs"
+                        )),
                     ],
                 ))
             ],


### PR DESCRIPTION
Relates to the broken fix from #1. On my machine this makes the test pass again at least.

Refs https://bugs.chromium.org/p/chromium/issues/detail?id=1466674

Reading that issue it sounds like the correct fix would be section `__DATA,__mod_init_func,mod_init_funcs`, but a symbol starting with `I`.