### PR TITLE
Support iOS and others with `target_vendor="apple"`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,9 +209,9 @@ pub fn ctor(args: TokenStream, input: TokenStream) -> TokenStream {
                 TokenTree::Group(Group::new(
                     Delimiter::Parenthesis,
                     tokens![
-                        TokenTree::Ident(Ident::new("target_os", Span::call_site())),
+                        TokenTree::Ident(Ident::new("target_vendor", Span::call_site())),
                         TokenTree::Punct(Punct::new('=', Spacing::Alone)),
-                        TokenTree::Literal(Literal::string("macos")),
+                        TokenTree::Literal(Literal::string("apple")),
                         TokenTree::Punct(Punct::new(',', Spacing::Alone)),
                         TokenTree::Ident(Ident::new("link_section", Span::call_site())),
                         TokenTree::Punct(Punct::new('=', Spacing::Alone)),


### PR DESCRIPTION
The `target_vendor="apple"` predicate can be used as a catch-all for all Apple OSes. They all use the Mach-O format, so the section name is the same as on macOS.

`cfg_target_vendor` was stabilized in Rust 1.33.

This mirrors mmastrac/rust-ctor#302